### PR TITLE
Fix unexpected string parsing with empty arguments

### DIFF
--- a/lib/nopt.js
+++ b/lib/nopt.js
@@ -327,6 +327,9 @@ function parse (args, data, remain, types, shorthands) {
         continue
       }
 
+      if (types[arg] === String && la === undefined)
+        la = ""
+
       if (la && la.match(/^-{2,}$/)) {
         la = undefined
         i --

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
   "main": "lib/nopt.js",
   "scripts": {
-    "test": "node lib/nopt.js"
+    "test": "node lib/nopt.js && tap test/*"
   },
   "repository": "http://github.com/isaacs/nopt",
   "bin": "./bin/nopt.js",
@@ -15,5 +15,8 @@
   },
   "dependencies": {
     "abbrev": "1"
+  },
+  "devDependencies": {
+    "tap": "~0.4.8"
   }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,0 +1,16 @@
+var nopt = require("../")
+  , test = require('tap').test
+
+
+test("passing a string results in a string", function (t) {
+  var parsed = nopt({ key: String }, {}, ["--key", "myvalue"], 0)
+  t.same(parsed.key, "myvalue")
+  t.end()
+})
+
+// https://github.com/npm/nopt/issues/31
+test("Empty String results in empty string, not true", function (t) {
+  var parsed = nopt({ empty: String }, {}, ["--empty"], 0)
+  t.same(parsed.empty, "")
+  t.end()
+})


### PR DESCRIPTION
Fix for an option with type String (e.g. `{foo: String}` that
does not get an argument passed e.g. `./myprogram --foo`.
The value for foo should be "" (empty String) and not
`true` (Boolean)

Fixes #38
