### PR TITLE
If the name property is supported by the environment use that for com…

### DIFF
--- a/lib/nopt.js
+++ b/lib/nopt.js
@@ -207,7 +207,7 @@ function validate (data, k, val, type, typeDefs) {
   for (var i = 0, l = types.length; i < l; i ++) {
     debug("test type %j %j %j", k, val, types[i])
     var t = typeDefs[types[i]]
-    if (t && type === t.type) {
+    if (t && ((type.name && t.type.name) ? (type.name === t.type.name) : (type === t.type))) {
       var d = {}
       ok = false !== t.validate(d, k, val)
       val = d[k]


### PR DESCRIPTION
…parison otherwise fall back to referential equality checking.


I have also experienced issue #48.  It causes Number objects to be discarded. Here are the changes proposed by @wbecker in a PR. All of the tests still run successfully.