### PR TITLE
Check types based on type.name equality in addition referential equality

### DIFF
--- a/lib/nopt.js
+++ b/lib/nopt.js
@@ -207,7 +207,10 @@ function validate (data, k, val, type, typeDefs) {
   for (var i = 0, l = types.length; i < l; i ++) {
     debug("test type %j %j %j", k, val, types[i])
     var t = typeDefs[types[i]]
-    if (t && type === t.type) {
+    if (t && ((type.name && t.type.name) ?
+      (type.name === t.type.name) :
+      (type === t.type))
+    ) {
       var d = {}
       ok = false !== t.validate(d, k, val)
       val = d[k]

--- a/test/basic.js
+++ b/test/basic.js
@@ -31,6 +31,21 @@ test("Unknown options are not parsed as numbers", function (t) {
     t.end()
 });
 
+// https://github.com/npm/nopt/issues/48
+test("Check types based on name of type", function (t) {
+  var parsed = nopt({"parse-me": {name: "Number"}}, null, ['--parse-me=1.20'], 0)
+  t.equal(parsed['parse-me'], 1.2)
+  t.end()
+})
+
+
+test("Types passed without a name are not parsed", function (t) {
+  var parsed = nopt({"parse-me": {}}, null, ['--parse-me=1.20'], 0)
+  //should only contain argv
+  t.equal(Object.keys(parsed).length, 1)
+  t.end()
+})
+
 test("other tests", function (t) {
 
   var util = require("util")


### PR DESCRIPTION
This is sometimes necessary if referential equality is broken, eg when
types are proxied.

Fixes #48 