### PR TITLE
support files uris like "file:///example"

### DIFF
--- a/lib/nopt.js
+++ b/lib/nopt.js
@@ -162,7 +162,7 @@ function validateBoolean (data, k, val) {
 
 function validateUrl (data, k, val) {
   val = url.parse(String(val))
-  if (!val.host) return false
+  if (!val.protocol) return false
   data[k] = val.href
 }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -110,6 +110,7 @@ test("other tests", function (t) {
       , viewer: path
       , _exit : Boolean
       , path: path
+      , url: url
       }
 
   ; [["-v", {version:true}, []]
@@ -228,6 +229,15 @@ test("other tests", function (t) {
      ,[]]
     ,["--path ."
      ,{"path":process.cwd()}
+     ,[]]
+    ,["--url http://localhost"
+     ,{"url":"http://localhost/"}
+     ,[]]
+    ,["--url file:///local/file"
+     ,{"url":"file:///local/file"}
+     ,[]]
+    ,["--url file://local/file"
+     ,{"url":"file://local/file"}
      ,[]]
     ].forEach(function (test) {
       var argv = test[0].split(/\s+/)


### PR DESCRIPTION
The problem as shown in tests is : `file:///local/file` is a valid URI (parsed by node's url module). But it's rejected by nopt because host is not set. 

By setting validateUrl to check on protocol, it goes through smoothly, while invalid strings not specifying protocol won't go through.
