### PR TITLE
Fix issue where abbrev wouldn't install

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "bin": "./bin/nopt.js",
   "license": "ISC",
   "dependencies": {
-    "abbrev": "1"
+    "abbrev": "^1.0.7"
   },
   "devDependencies": {
     "tap": "^1.2.0"


### PR DESCRIPTION
Closes #59.
![](http://d.pr/i/1jXSI+)

Not sure why, but sometimes `abbrev` isn't getting installed correctly. Either way, the dependency should be updated to the above.
