### PR TITLE
arg.match is no longer called if arg is not a string.

### DIFF
--- a/lib/nopt.js
+++ b/lib/nopt.js
@@ -237,7 +237,7 @@ function parse (args, data, remain, types, shorthands) {
     var arg = args[i]
     debug("arg", arg)
 
-    if (arg.match(/^-{2,}$/)) {
+    if (typeof arg == 'string' && arg.match(/^-{2,}$/)) {
       // done with keys.
       // the rest are args.
       remain.push.apply(remain, args.slice(i + 1))
@@ -245,7 +245,7 @@ function parse (args, data, remain, types, shorthands) {
       break
     }
     var hadEq = false
-    if (arg.charAt(0) === "-" && arg.length > 1) {
+    if (typeof arg == 'string' && arg.charAt(0) === "-" && arg.length > 1) {
       if (arg.indexOf("=") !== -1) {
         hadEq = true
         var v = arg.split("=")


### PR DESCRIPTION
arg.match resulted in an exception if arg was not a string.