### PR TITLE
replace key-value extraction with simpler version

### DIFF
--- a/lib/nopt.js
+++ b/lib/nopt.js
@@ -246,12 +246,12 @@ function parse (args, data, remain, types, shorthands) {
     }
     var hadEq = false
     if (arg.charAt(0) === "-" && arg.length > 1) {
-      if (arg.indexOf("=") !== -1) {
+      var at = arg.indexOf('=')
+      if (at > -1) {
         hadEq = true
-        var v = arg.split("=")
-        arg = v.shift()
-        v = v.join("=")
-        args.splice.apply(args, [i, 1].concat([arg, v]))
+        var v = arg.substr(at + 1)
+        arg = arg.substr(0, at)
+        args.splice(i, 1, arg, v)
       }
 
       // see if it's a shorthand


### PR DESCRIPTION
This implementation replaces the older one to:

1. get index once for `if` and reuse internally for each substr()
2. avoid using split() which searches for the equal sign again, and, would split at all equal signs.
3. avoid using join() to put the value back together.
4. use substr() with index to get both key and value.
5. call splice() directly with args instead of using apply() with an array. Avoids creating two 2 element arrays and then a 4 element array via concat()
