### PR TITLE
create argv with three vars inside and then ref remain in it

### DIFF
--- a/lib/nopt.js
+++ b/lib/nopt.js
@@ -33,14 +33,16 @@ function nopt (types, shorthands, args, slice) {
   args = args.slice(slice)
   var data = {}
     , key
-    , remain = []
-    , cooked = args
-    , original = args.slice(0)
+    , argv = {
+        remain: [],
+        cooked: args,
+        original: args.slice(0)
+      }
 
-  parse(args, data, remain, types, shorthands)
+  parse(args, data, argv.remain, types, shorthands)
   // now data is full
   clean(data, types, exports.typeDefs)
-  data.argv = {remain:remain,cooked:cooked,original:original}
+  data.argv = argv
   Object.defineProperty(data.argv, 'toString', { value: function () {
     return this.original.map(JSON.stringify).join(" ")
   }, enumerable: false })


### PR DESCRIPTION
Instead of creating three vars separately and then combining them in an object a few lines later, create them already combined in an object. Then, reference the one used outside it when calling `parse()`.