### PR TITLE
store Array.isArray(types[arg]) for multiple reuses

### DIFF
--- a/lib/nopt.js
+++ b/lib/nopt.js
@@ -275,8 +275,9 @@ function parse (args, data, remain, types, shorthands) {
 
       if (abbrevs[arg]) arg = abbrevs[arg]
 
-      var isArray = types[arg] === Array ||
-        Array.isArray(types[arg]) && types[arg].indexOf(Array) !== -1
+      var isTypeArray = Array.isArray(types[arg])
+        , isArray = types[arg] === Array ||
+        isTypeArray && types[arg].indexOf(Array) !== -1
 
       // allow unknown things to be arrays if specified multiple times.
       if (!types.hasOwnProperty(arg) && data.hasOwnProperty(arg)) {
@@ -290,11 +291,11 @@ function parse (args, data, remain, types, shorthands) {
 
       var isBool = typeof no === 'boolean' ||
         types[arg] === Boolean ||
-        Array.isArray(types[arg]) && types[arg].indexOf(Boolean) !== -1 ||
+        isTypeArray && types[arg].indexOf(Boolean) !== -1 ||
         (typeof types[arg] === 'undefined' && !hadEq) ||
         (la === "false" &&
          (types[arg] === null ||
-          Array.isArray(types[arg]) && ~types[arg].indexOf(null)))
+          isTypeArray && ~types[arg].indexOf(null)))
 
       if (isBool) {
         // just set and move along
@@ -308,7 +309,7 @@ function parse (args, data, remain, types, shorthands) {
         }
 
         // also support "foo":[Boolean, "bar"] and "--foo bar"
-        if (Array.isArray(types[arg]) && la) {
+        if (isTypeArray && la) {
           if (~types[arg].indexOf(la)) {
             // an explicit type
             val = la


### PR DESCRIPTION
Replace four close uses of `Array.isArray(types[arg])` with reuse of a var with that value.