### PR TITLE
call Date.parse(val) once instead of twice

### DIFF
--- a/lib/nopt.js
+++ b/lib/nopt.js
@@ -144,8 +144,8 @@ function validateNumber (data, k, val) {
 }
 
 function validateDate (data, k, val) {
-  debug("validate Date %j %j %j", k, val, Date.parse(val))
   var s = Date.parse(val)
+  debug("validate Date %j %j %j", k, val, s)
   if (isNaN(s)) return false
   data[k] = new Date(val)
 }


### PR DESCRIPTION
If it's going to create a problem preventing the debug call then it'll create the problem even when it's the last arg to debug. So, might as well do it once, first, and then use that result in the debug call.