### PR TITLE
Fix two windows issues

### DIFF
--- a/lib/nopt.js
+++ b/lib/nopt.js
@@ -129,11 +129,16 @@ function validatePath (data, k, val) {
   if (val === null) return true
 
   val = String(val)
-  var homePattern = process.platform === 'win32' ? /^~(\/|\\)/ : /^~\//
-  if (val.match(homePattern) && process.env.HOME) {
-    val = path.resolve(process.env.HOME, val.substr(2))
+
+  var isWin       = process.platform === 'win32'
+    , homePattern = isWin ? /^~(\/|\\)/ : /^~\//
+    , home        = isWin ? process.env.USERPROFILE : process.env.HOME
+
+  if (home && val.match(homePattern)) {
+    data[k] = path.resolve(home, val.substr(2))
+  } else {
+    data[k] = path.resolve(val)
   }
-  data[k] = path.resolve(String(val))
   return true
 }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,6 +1,6 @@
 var nopt = require("../")
   , test = require('tap').test
-
+  , isWin = process.platform === 'win32'
 
 test("passing a string results in a string", function (t) {
   var parsed = nopt({ key: String }, {}, ["--key", "myvalue"], 0)
@@ -148,7 +148,7 @@ test("other tests", function (t) {
     ,["--color --logfd 7", {logfd:7,color:true}, []]
     ,["--color=true", {color:true}, []]
     ,["--logfd=10", {logfd:10}, []]
-    ,["--tmp=/tmp -tar=gtar",{tmp:"/tmp",tar:"gtar"},[]]
+    ,["--tmp=/tmp -tar=gtar", {tmp: isWin ? "C:\\tmp" : "/tmp",tar:"gtar"},[]]
     ,["--tmp=tmp -tar=gtar",
       {tmp:path.resolve(process.cwd(), "tmp"),tar:"gtar"},[]]
     ,["--logfd x", {}, []]

--- a/test/basic.js
+++ b/test/basic.js
@@ -15,11 +15,26 @@ test("Empty String results in empty string, not true", function (t) {
   t.end()
 })
 
-test("~ path is resolved to $HOME", function (t) {
+test("~ path is resolved to " + (isWin ? '%USERPROFILE%' : '$HOME'), function (t) {
   var path = require("path")
-  if (!process.env.HOME) process.env.HOME = "/tmp"
-  var parsed = nopt({key: path}, {}, ["--key=~/val"], 0)
-  t.same(parsed.key, path.resolve(process.env.HOME, "val"))
+    , the
+
+  if (isWin) {
+    the = {
+      key: 'USERPROFILE',
+      dir: 'C:\\temp',
+      val: '~\\val'
+    }
+  } else {
+    the = {
+      key: 'HOME',
+      dir: '/tmp',
+      val: '~/val'
+    }
+  }
+  if (!process.env[the.key]) process.env[the.key] = v.dir
+  var parsed = nopt({key: path}, {}, ["--key=" + the.val], 0)
+  t.same(parsed.key, path.resolve(process.env[the.key], "val"))
   t.end()
 })
 


### PR DESCRIPTION
Fixed a test which fails on Windows because it expects `/tmp` and receives `C:\\tmp`.

Fixed `validatePath()` to use `process.env.USERPROFILE` when on the windows platform because on windows Node doesn't provide `process.env.HOME`. It already had a different regular expression for the windows platform (accepting backward slash as well as forward) so, now it uses a different environment variable as well.

Created an `isWin` at the top for repeated use.

Also removed the extra call to `String()` around `val` when it's not a home prefixed path. In that execution, we already did `val = String(val)` above, so, doing it a second time in `data[k] = path.resolve(String(val))` is unnecessary. If `val` wasn't already a String instance then the `val.match()` call would fail, too.

Changed the `$HOME` test to alternate between windows and *nix version based on platform. (Also, my commit message has my `$HOME` value in it because it replaced `$HOME` on me, of course, which I didn't notice. So, that message should say `$HOME` instead of `/Users/eli`, doh).