### PR TITLE
Replace osenv by native Node.js os core module

### DIFF
--- a/lib/nopt.js
+++ b/lib/nopt.js
@@ -8,7 +8,7 @@ var url = require("url")
   , path = require("path")
   , Stream = require("stream").Stream
   , abbrev = require("abbrev")
-  , osenv = require("osenv")
+  , os = require("os")
 
 module.exports = exports = nopt
 exports.clean = clean
@@ -140,7 +140,7 @@ function validatePath (data, k, val) {
 
   var isWin       = process.platform === 'win32'
     , homePattern = isWin ? /^~(\/|\\)/ : /^~\//
-    , home        = osenv.home()
+    , home        = os.homedir()
 
   if (home && val.match(homePattern)) {
     data[k] = path.resolve(home, val.substr(2))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1389,21 +1389,8 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "own-or": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   "bin": "./bin/nopt.js",
   "license": "ISC",
   "dependencies": {
-    "abbrev": "1",
-    "osenv": "^0.1.4"
+    "abbrev": "1"
   },
   "devDependencies": {
     "tap": "^14.10.6"


### PR DESCRIPTION
# What / Why
Replace the osenv module with the native Node.js os core module. This pull-request replace the osenv.home() with os.homedir().

Best Regards,
Thomas
