### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/nopt.js
+++ b/lib/nopt.js
@@ -143,7 +143,7 @@ function validatePath (data, k, val) {
     , home        = os.homedir()
 
   if (home && val.match(homePattern)) {
-    data[k] = path.resolve(home, val.substr(2))
+    data[k] = path.resolve(home, val.slice(2))
   } else {
     data[k] = path.resolve(val)
   }
@@ -262,8 +262,8 @@ function parse (args, data, remain, types, shorthands) {
       var at = arg.indexOf('=')
       if (at > -1) {
         hadEq = true
-        var v = arg.substr(at + 1)
-        arg = arg.substr(0, at)
+        var v = arg.slice(at + 1)
+        arg = arg.slice(0, at)
         args.splice(i, 1, arg, v)
       }
 
@@ -283,7 +283,7 @@ function parse (args, data, remain, types, shorthands) {
       var no = null
       while (arg.toLowerCase().indexOf("no-") === 0) {
         no = !no
-        arg = arg.substr(3)
+        arg = arg.slice(3)
       }
 
       if (abbrevs[arg]) arg = abbrevs[arg]


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.