### PR TITLE
url.parse and debug

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -32,10 +32,6 @@ jobs:
         with:
           node-version: 24.x
           check-latest: contains('24.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund --package-lock
       - name: Run Production Audit

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -85,7 +85,7 @@ jobs:
             os: macos-latest
             shell: bash
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             shell: bash
         node-version:
           - 20.17.0
@@ -94,15 +94,15 @@ jobs:
           - 22.x
           - 24.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 20.17.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 20.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.9.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 24.x
     runs-on: ${{ matrix.platform.os }}
     defaults:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -53,10 +53,6 @@ jobs:
         with:
           node-version: 24.x
           check-latest: contains('24.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -131,10 +127,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Test (with coverage on Node >= 24)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,6 @@ jobs:
         with:
           node-version: 24.x
           check-latest: contains('24.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -97,10 +93,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Test (with coverage on Node >= 24)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
             os: macos-latest
             shell: bash
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             shell: bash
         node-version:
           - 20.17.0
@@ -70,15 +70,15 @@ jobs:
           - 22.x
           - 24.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 20.17.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 20.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.9.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 24.x
     runs-on: ${{ matrix.platform.os }}
     defaults:

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -30,10 +30,6 @@ jobs:
         with:
           node-version: 24.x
           check-latest: contains('24.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Fetch Dependabot Metadata

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,10 +36,6 @@ jobs:
         with:
           node-version: 24.x
           check-latest: contains('24.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Run Commitlint on Commits

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -47,10 +47,6 @@ jobs:
         with:
           node-version: 24.x
           check-latest: contains('24.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Set npm authToken

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,6 @@ jobs:
         with:
           node-version: 24.x
           check-latest: contains('24.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Release Please
@@ -121,10 +117,6 @@ jobs:
         with:
           node-version: 24.x
           check-latest: contains('24.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Create Release Manager Checklist Text

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,6 +1,0 @@
-/* node:coverage disable */
-module.exports = process.env.DEBUG_NOPT || process.env.NOPT_DEBUG
-  // eslint-disable-next-line no-console
-  ? (...a) => console.error(...a)
-  : () => {}
-/* node:coverage enable */

--- a/lib/nopt-lib.js
+++ b/lib/nopt-lib.js
@@ -1,5 +1,4 @@
 const abbrev = require('abbrev')
-const debug = require('./debug')
 const defaultTypeDefs = require('./type-defs')
 
 const hasOwn = (o, k) => Object.prototype.hasOwnProperty.call(o, k)
@@ -31,8 +30,6 @@ function nopt (args, {
   typeDefault,
   dynamicTypes,
 } = {}) {
-  debug(types, shorthands, args, typeDefs)
-
   const data = {}
   const argv = {
     remain: [],
@@ -89,7 +86,6 @@ function clean (data, {
       return
     }
     let val = data[k]
-    debug('val=%j', val)
     const isArray = Array.isArray(val)
     let [hasType, rawType] = getType(k, { types, dynamicTypes })
     let type = rawType
@@ -106,12 +102,9 @@ function clean (data, {
       type = [type]
     }
 
-    debug('val=%j', val)
-    debug('types=', type)
     val = val.map((v) => {
       // if it's an unknown value, then parse false/true/null/numbers/dates
       if (typeof v === 'string') {
-        debug('string %j', v)
         v = v.trim()
         if ((v === 'null' && ~type.indexOf(null))
             || (v === 'true' &&
@@ -119,12 +112,9 @@ function clean (data, {
             || (v === 'false' &&
                (~type.indexOf(false) || hasTypeDef(type, BooleanType)))) {
           v = JSON.parse(v)
-          debug('jsonable %j', v)
         } else if (hasTypeDef(type, NumberType) && !isNaN(v)) {
-          debug('convert to number', v)
           v = +v
         } else if (hasTypeDef(type, DateType) && !isNaN(Date.parse(v))) {
-          debug('convert to date', v)
           v = new Date(v)
         }
       }
@@ -148,32 +138,24 @@ function clean (data, {
 
       const d = {}
       d[k] = v
-      debug('prevalidated val', d, v, rawType)
       if (!validate(d, k, v, rawType, { typeDefs })) {
         if (invalidHandler) {
           invalidHandler(k, v, rawType, data)
-        } else if (invalidHandler !== false) {
-          debug('invalid: ' + k + '=' + v, rawType)
         }
         return remove
       }
-      debug('validated v', d, v, rawType)
       return d[k]
     }).filter((v) => v !== remove)
 
     // if we allow Array specifically, then an empty array is how we
     // express 'no value here', not null.  Allow it.
     if (!val.length && doesNotHaveTypeDef(type, ArrayType)) {
-      debug('VAL HAS NO LENGTH, DELETE IT', val, k, type.indexOf(ArrayType))
       delete data[k]
     } else if (isArray) {
-      debug(isArray, data[k], val)
       data[k] = val
     } else {
       data[k] = val[0]
     }
-
-    debug('k=%s val=%j', k, val, data[k])
   })
 }
 
@@ -206,14 +188,12 @@ function validate (data, k, val, type, { typeDefs } = {}) {
   // this repo. Leaving as-is for now.
   /* eslint-disable-next-line no-self-compare */
   if (type !== type) {
-    debug('Poison NaN', k, val, type)
     delete data[k]
     return false
   }
 
   // explicit list of values
   if (val === type) {
-    debug('Explicitly allowed %j', val)
     data[k] = val
     return true
   }
@@ -222,7 +202,6 @@ function validate (data, k, val, type, { typeDefs } = {}) {
   let ok = false
   const types = Object.keys(typeDefs)
   for (let i = 0, l = types.length; i < l; i++) {
-    debug('test type %j %j %j', k, val, types[i])
     const t = typeDefs[types[i]]
     if (t && (
       (type && type.name && t.type && t.type.name) ?
@@ -238,7 +217,6 @@ function validate (data, k, val, type, { typeDefs } = {}) {
       }
     }
   }
-  debug('OK? %j (%j %j %j)', ok, k, val, types[types.length - 1])
 
   if (!ok) {
     delete data[k]
@@ -258,16 +236,11 @@ function parse (args, data, remain, {
   const NumberType = typeDefs.Number?.type
   const ArrayType = typeDefs.Array?.type
   const BooleanType = typeDefs.Boolean?.type
-
-  debug('parse', args, data, remain)
-
   const abbrevs = abbrev(Object.keys(types))
-  debug('abbrevs=%j', abbrevs)
   const shortAbbr = abbrev(Object.keys(shorthands))
 
   for (let i = 0; i < args.length; i++) {
     let arg = args[i]
-    debug('arg', arg)
 
     if (arg.match(/^-{2,}$/)) {
       // done with keys.
@@ -289,7 +262,6 @@ function parse (args, data, remain, {
       // see if it's a shorthand
       // if so, splice and back up to re-parse it.
       const shRes = resolveShort(arg, shortAbbr, abbrevs, { shorthands, abbrevHandler })
-      debug('arg=%j shRes=%j', arg, shRes)
       if (shRes) {
         args.splice.apply(args, [i, 1].concat(shRes))
         if (arg !== shRes[0]) {
@@ -308,8 +280,6 @@ function parse (args, data, remain, {
       if (abbrevs[arg] && abbrevs[arg] !== arg) {
         if (abbrevHandler) {
           abbrevHandler(arg, abbrevs[arg])
-        } else if (abbrevHandler !== false) {
-          debug(`abbrev: ${arg} -> ${abbrevs[arg]}`)
         }
         arg = abbrevs[arg]
       }
@@ -351,11 +321,6 @@ function parse (args, data, remain, {
             unknownHandler(arg, la)
           } else {
             unknownHandler(arg)
-          }
-        } else if (unknownHandler !== false) {
-          debug(`unknown: ${arg}`)
-          if (hangingLa) {
-            debug(`unknown: ${la} parsed as normal opt`)
           }
         }
       }
@@ -442,7 +407,6 @@ const singleCharacters = (arg, shorthands) => {
       return l
     }, {})
     shorthands[SINGLES] = singles
-    debug('shorthand singles', singles)
   }
   const chrs = arg.split('').filter((c) => singles[c])
   return chrs.join('') === arg ? chrs : null
@@ -490,8 +454,6 @@ function resolveShort (arg, ...rest) {
   if (shortAbbr[arg]) {
     if (abbrevHandler) {
       abbrevHandler(arg, shortAbbr[arg])
-    } else if (abbrevHandler !== false) {
-      debug(`abbrev: ${arg} -> ${shortAbbr[arg]}`)
     }
     arg = shortAbbr[arg]
   }

--- a/lib/nopt-lib.js
+++ b/lib/nopt-lib.js
@@ -181,11 +181,13 @@ function validate (data, k, val, type, { typeDefs } = {}) {
   }
 
   // Original comment:
-  // NaN is poisonous.  Means that something is not allowed.
-  // New comment: Changing this to an isNaN check breaks a lot of tests.
-  // Something is being assumed here that is not actually what happens in
-  // practice.  Fixing it is outside the scope of getting linting to pass in
-  // this repo. Leaving as-is for now.
+  // NaN is poisonous, it means that something is not allowed.
+
+  // New comment:
+  // Changing this to an isNaN check breaks a lot of tests.
+  // Something is being assumed here that is not actually what happens in practice.
+  // Fixing it is outside the scope of getting linting to pass in this repo.
+  // Leaving as-is for now.
   /* eslint-disable-next-line no-self-compare */
   if (type !== type) {
     delete data[k]

--- a/lib/nopt.js
+++ b/lib/nopt.js
@@ -1,10 +1,8 @@
 const lib = require('./nopt-lib')
 const defaultTypeDefs = require('./type-defs')
 
-// This is the version of nopt's API that requires setting typeDefs and invalidHandler
-// on the required `nopt` object since it is a singleton. To not do a breaking change
-// an API that requires all options be passed in is located in `nopt-lib.js` and
-// exported here as lib.
+// This is the version of nopt's API that requires setting typeDefs and invalidHandler on the required `nopt` object since it is a singleton.
+// To not do a breaking change an API that requires all options be passed in is located in `nopt-lib.js` and exported here as lib.
 // TODO(breaking): make API only work in non-singleton mode
 
 module.exports = exports = nopt

--- a/lib/type-defs.js
+++ b/lib/type-defs.js
@@ -1,7 +1,7 @@
-const url = require('url')
-const path = require('path')
-const Stream = require('stream').Stream
-const os = require('os')
+const { URL } = require('node:url')
+const path = require('node:path')
+const { Stream } = require('node:stream')
+const os = require('node:os')
 const debug = require('./debug')
 
 function validateString (data, k, val) {
@@ -63,13 +63,11 @@ function validateBoolean (data, k, val) {
 }
 
 function validateUrl (data, k, val) {
-  // Changing this would be a breaking change in the npm cli
-  /* eslint-disable-next-line node/no-deprecated-api */
-  val = url.parse(String(val))
-  if (!val.host) {
+  const parsed = URL.parse(String(val))
+  if (!parsed) {
     return false
   }
-  data[k] = val.href
+  data[k] = parsed.href
 }
 
 function validateStream (data, k, val) {
@@ -82,7 +80,7 @@ function validateStream (data, k, val) {
 module.exports = {
   String: { type: String, validate: validateString },
   Boolean: { type: Boolean, validate: validateBoolean },
-  url: { type: url, validate: validateUrl },
+  url: { type: URL, validate: validateUrl },
   Number: { type: Number, validate: validateNumber },
   path: { type: path, validate: validatePath },
   Stream: { type: Stream, validate: validateStream },

--- a/lib/type-defs.js
+++ b/lib/type-defs.js
@@ -1,8 +1,7 @@
-const { URL } = require('node:url')
+const os = require('node:os')
 const path = require('node:path')
 const { Stream } = require('node:stream')
-const os = require('node:os')
-const debug = require('./debug')
+const { URL } = require('node:url')
 
 function validateString (data, k, val) {
   data[k] = String(val)
@@ -31,7 +30,6 @@ function validatePath (data, k, val) {
 }
 
 function validateNumber (data, k, val) {
-  debug('validate Number %j %j %j', k, val, isNaN(val))
   if (isNaN(val)) {
     return false
   }
@@ -40,7 +38,6 @@ function validateNumber (data, k, val) {
 
 function validateDate (data, k, val) {
   const s = Date.parse(val)
-  debug('validate Date %j %j %j', k, val, s)
   if (isNaN(s)) {
     return false
   }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "version": "4.30.0",
     "publish": true,
     "testRunner": "node:test",
-    "latestCiVersion": 24
+    "latestCiVersion": 24,
+    "updateNpm": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^6.0.0",
-    "@npmcli/template-oss": "4.28.1"
+    "@npmcli/template-oss": "4.30.0"
   },
   "files": [
     "bin/",
@@ -41,7 +41,7 @@
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
     "windowsCI": false,
-    "version": "4.28.1",
+    "version": "4.30.0",
     "publish": true,
     "testRunner": "node:test",
     "latestCiVersion": 24

--- a/test/basic.js
+++ b/test/basic.js
@@ -2,6 +2,7 @@ const nopt = require('../')
 const { test } = require('node:test')
 const assert = require('node:assert')
 const isWin = process.platform === 'win32'
+const { URL } = require('url')
 
 test('empty array is fine if type includes Array', () => {
   const types = {
@@ -97,83 +98,82 @@ test('clean: no types does not throw', () => {
 test('other tests', () => {
   const Stream = require('stream')
   const path = require('path')
-  const url = require('url')
+  const shorthands = {
+    s: ['--loglevel', 'silent'],
+    d: ['--loglevel', 'info'],
+    dd: ['--loglevel', 'verbose'],
+    ddd: ['--loglevel', 'silly'],
+    noreg: ['--no-registry'],
+    reg: ['--registry'],
+    'no-reg': ['--no-registry'],
+    silent: ['--loglevel', 'silent'],
+    verbose: ['--loglevel', 'verbose'],
+    h: ['--usage'],
+    H: ['--usage'],
+    '?': ['--usage'],
+    help: ['--usage'],
+    v: ['--version'],
+    f: ['--force'],
+    desc: ['--description'],
+    'no-desc': ['--no-description'],
+    local: ['--no-global'],
+    l: ['--long'],
+    p: ['--parseable'],
+    porcelain: ['--parseable'],
+    g: ['--global'],
+  }
 
-  const shorthands =
-      { s: ['--loglevel', 'silent'],
-        d: ['--loglevel', 'info'],
-        dd: ['--loglevel', 'verbose'],
-        ddd: ['--loglevel', 'silly'],
-        noreg: ['--no-registry'],
-        reg: ['--registry'],
-        'no-reg': ['--no-registry'],
-        silent: ['--loglevel', 'silent'],
-        verbose: ['--loglevel', 'verbose'],
-        h: ['--usage'],
-        H: ['--usage'],
-        '?': ['--usage'],
-        help: ['--usage'],
-        v: ['--version'],
-        f: ['--force'],
-        desc: ['--description'],
-        'no-desc': ['--no-description'],
-        local: ['--no-global'],
-        l: ['--long'],
-        p: ['--parseable'],
-        porcelain: ['--parseable'],
-        g: ['--global'],
-      }
+  const types = {
+    aoa: Array,
+    nullstream: [null, Stream],
+    date: Date,
+    str: String,
+    browser: String,
+    cache: path,
+    color: ['always', Boolean],
+    depth: Number,
+    description: Boolean,
+    dev: Boolean,
+    editor: path,
+    force: Boolean,
+    global: Boolean,
+    globalconfig: path,
+    group: [String, Number],
+    gzipbin: String,
+    logfd: [Number, Stream],
+    loglevel: ['silent', 'win', 'error', 'warn', 'info', 'verbose', 'silly'],
+    long: Boolean,
+    'node-version': [false, String],
+    npaturl: URL,
+    npat: Boolean,
+    'onload-script': [false, String],
+    outfd: [Number, Stream],
+    parseable: Boolean,
+    pre: Boolean,
+    prefix: path,
+    proxy: URL,
+    'rebuild-bundle': Boolean,
+    registry: URL,
+    searchopts: String,
+    searchexclude: [null, String],
+    shell: path,
+    t: [Array, String],
+    tag: String,
+    tar: String,
+    tmp: path,
+    'unsafe-perm': Boolean,
+    usage: Boolean,
+    user: String,
+    username: String,
+    userconfig: path,
+    version: Boolean,
+    viewer: path,
+    _exit: Boolean,
+    path: path,
+  }
 
-  const types =
-      { aoa: Array,
-        nullstream: [null, Stream],
-        date: Date,
-        str: String,
-        browser: String,
-        cache: path,
-        color: ['always', Boolean],
-        depth: Number,
-        description: Boolean,
-        dev: Boolean,
-        editor: path,
-        force: Boolean,
-        global: Boolean,
-        globalconfig: path,
-        group: [String, Number],
-        gzipbin: String,
-        logfd: [Number, Stream],
-        loglevel: ['silent', 'win', 'error', 'warn', 'info', 'verbose', 'silly'],
-        long: Boolean,
-        'node-version': [false, String],
-        npaturl: url,
-        npat: Boolean,
-        'onload-script': [false, String],
-        outfd: [Number, Stream],
-        parseable: Boolean,
-        pre: Boolean,
-        prefix: path,
-        proxy: url,
-        'rebuild-bundle': Boolean,
-        registry: url,
-        searchopts: String,
-        searchexclude: [null, String],
-        shell: path,
-        t: [Array, String],
-        tag: String,
-        tar: String,
-        tmp: path,
-        'unsafe-perm': Boolean,
-        usage: Boolean,
-        user: String,
-        username: String,
-        userconfig: path,
-        version: Boolean,
-        viewer: path,
-        _exit: Boolean,
-        path: path,
-      }
-
-  ; [['-v', { version: true }, []],
+  const paramsToTest = [
+    ['-v', { version: true }, []],
     ['---v', { version: true }, []],
     ['ls -s --no-reg connect -d',
       { loglevel: 'info', registry: null }, ['ls', 'connect']],
@@ -296,7 +296,8 @@ test('other tests', () => {
     ['--path .',
       { path: process.cwd() },
       []],
-  ].forEach(function (params) {
+  ]
+  for (const params of paramsToTest) {
     const argv = params[0].split(/\s+/)
     const opts = params[1]
     const rem = params[2]
@@ -313,7 +314,7 @@ test('other tests', () => {
       }
     }
     assert.deepStrictEqual(rem, parsed.remain)
-  })
+  }
 })
 
 test('argv toString()', () => {


### PR DESCRIPTION
This contains two breaking changes:

- move from url.parse to URL.parse so we no longer get deprecation warnings about it.  The differences are minor but still breaking
- remove the custom debug implementation.  We don't really use this now that development on this lib has slowed down and if we wanted to do this in the future we'd use a different approach most likely

Also the comments were inlined.  This PR will need to be rebase merged to have all these show up in the changelog.

fixes https://github.com/npm/statusboard/issues/1079