### PR TITLE
docs: remove stale DEBUG_NOPT / NOPT_DEBUG references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,6 @@ config object and remove its invalid properties.
 
 ## Error Handling
 
-By default nopt logs debug messages if `DEBUG_NOPT` or `NOPT_DEBUG` are set in the environment.
-
 You can assign the following methods to `nopt` for a more granular notification of invalid, unknown, and expanding options:
 
 `nopt.invalidHandler(key, value, type, data)` - Called when a value is invalid for its option.

--- a/README.md
+++ b/README.md
@@ -147,8 +147,6 @@ You can assign the following methods to `nopt` for a more granular notification 
 `nopt.unknownHandler(key, next)` - Called when an option is found that has no configuration.  In certain situations the next option on the command line will be parsed on its own instead of as part of the unknown option. In this case `next` will contain that option.
 `nopt.abbrevHandler(short, long)` - Called when an option is automatically translated via abbreviations.
 
-You can also set any of these to `false` to disable the debugging messages that they generate.
-
 ## Abbreviations
 
 Yes, they are supported.  If you define options like this:


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
removes stale DEBUG_NOPT / NOPT_DEBUG references from README. follow up to #197 

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
fixes: #198 