### PR TITLE
docs: remove stale debug env references

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,15 +141,13 @@ config object and remove its invalid properties.
 
 ## Error Handling
 
-By default nopt logs debug messages if `DEBUG_NOPT` or `NOPT_DEBUG` are set in the environment.
-
-You can assign the following methods to `nopt` for a more granular notification of invalid, unknown, and expanding options:
+You can assign the following methods to `nopt` for notification of invalid, unknown, and expanding options:
 
 `nopt.invalidHandler(key, value, type, data)` - Called when a value is invalid for its option.
 `nopt.unknownHandler(key, next)` - Called when an option is found that has no configuration.  In certain situations the next option on the command line will be parsed on its own instead of as part of the unknown option. In this case `next` will contain that option.
 `nopt.abbrevHandler(short, long)` - Called when an option is automatically translated via abbreviations.
 
-You can also set any of these to `false` to disable the debugging messages that they generate.
+You can set any of these to `false` or leave them unset to skip that notification.
 
 ## Abbreviations
 


### PR DESCRIPTION
## What / Why
Removes stale README references to `DEBUG_NOPT` and `NOPT_DEBUG` after debug console output was removed.

Closes #198.

## Testing
- `git diff --check`
- `rg -n "DEBUG_NOPT|NOPT_DEBUG|debugging messages|debug messages" README.md lib test` (no matches)
