### PR TITLE
fix: avoid crash on prototype shorthand options

### DIFF
--- a/lib/nopt-lib.js
+++ b/lib/nopt-lib.js
@@ -279,7 +279,7 @@ function parse (args, data, remain, {
       }
 
       // abbrev includes the original full string in its abbrev list
-      if (abbrevs[arg] && abbrevs[arg] !== arg) {
+      if (hasOwn(abbrevs, arg) && abbrevs[arg] !== arg) {
         if (abbrevHandler) {
           abbrevHandler(arg, abbrevs[arg])
         }
@@ -426,12 +426,12 @@ function resolveShort (arg, ...rest) {
   arg = arg.replace(/^-+/, '')
 
   // if it's an exact known option, then don't go any further
-  if (abbrevs[arg] === arg) {
+  if (hasOwn(abbrevs, arg) && abbrevs[arg] === arg) {
     return null
   }
 
   // if it's an exact known shortopt, same deal
-  if (shorthands[arg]) {
+  if (hasOwn(shorthands, arg)) {
     // make it an array, if it's a list of words
     if (shorthands[arg] && !Array.isArray(shorthands[arg])) {
       shorthands[arg] = shorthands[arg].split(/\s+/)
@@ -447,13 +447,13 @@ function resolveShort (arg, ...rest) {
   }
 
   // if it's an arg abbrev, and not a literal shorthand, then prefer the arg
-  if (abbrevs[arg] && !shorthands[arg]) {
+  if (hasOwn(abbrevs, arg) && !hasOwn(shorthands, arg)) {
     return null
   }
 
   // if it's an abbr for a shorthand, then use that
   // exact match has already happened so we don't need to account for that here
-  if (shortAbbr[arg]) {
+  if (hasOwn(shortAbbr, arg)) {
     if (abbrevHandler) {
       abbrevHandler(arg, shortAbbr[arg])
     }
@@ -461,11 +461,11 @@ function resolveShort (arg, ...rest) {
   }
 
   // make it an array, if it's a list of words
-  if (shorthands[arg] && !Array.isArray(shorthands[arg])) {
+  if (hasOwn(shorthands, arg) && !Array.isArray(shorthands[arg])) {
     shorthands[arg] = shorthands[arg].split(/\s+/)
   }
 
-  return shorthands[arg]
+  return hasOwn(shorthands, arg) ? shorthands[arg] : undefined
 }
 
 module.exports = {

--- a/test/lib.js
+++ b/test/lib.js
@@ -33,6 +33,14 @@ test('no/missing options', () => {
   assert.doesNotThrow(() => noptLib.resolveShort('', {}, {}, {}))
 })
 
+test('prototype names are not treated as shorthands', () => {
+  for (const name of ['toString', 'valueOf', 'hasOwnProperty', 'isPrototypeOf']) {
+    const parsed = noptLib.nopt([`--${name}`, 'value'])
+    assert.strictEqual(parsed[name], 'value')
+    assert.ok(Object.prototype.hasOwnProperty.call(parsed, name))
+  }
+})
+
 test('key argv is ignored', (t) => {
   nopt(t, ['--argvv', '--argv'], {}, {
     argvv: true,


### PR DESCRIPTION
Fixes #208.

Guard shorthand expansion against prototype-inherited names so inputs such as `--constructor` do not trigger a runtime crash. Adds regression coverage.

Tests: full suite (48 passed), 100% line/branch/function coverage, and ESLint.